### PR TITLE
fix: update content script match pattern

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -24,7 +24,7 @@
     },
     "content_scripts": [
       {
-        "matches": ["*://web.snapchat.com/*"],
+        "matches": ["*://snapchat.com/web/*"],
         "js": ["snapenhance.js"],
         "run_at": "document_start"
       }


### PR DESCRIPTION
This pull request includes a change to the `extension/manifest.json` file to update the URL pattern for content scripts. The change modifies the URL pattern to ensure the script matches the correct Snapchat web URLs.

* [`extension/manifest.json`](diffhunk://#diff-1929f2f40162baf33d4a074cc7a94593fc44ffb991fd7a7f597f90643da7f7f4L27-R27): Updated the `matches` pattern from `*://web.snapchat.com/*` to `*://snapchat.com/web/*` to correctly target Snapchat web URLs.